### PR TITLE
Update Exfiltration.md

### DIFF
--- a/ThreatIntel/ExtraThreatIntel.md
+++ b/ThreatIntel/ExtraThreatIntel.md
@@ -42,6 +42,7 @@
 | 21 June 2021 | PYSA | https://blogs.blackberry.com/en/2021/06/pysa-loves-chachi-a-new-golang-rat |
 | 6 May 2021 | FiveHands | https://www.cisa.gov/news-events/analysis-reports/ar21-126a |
 | 5 July 2020 | MAZE | https://cloud.google.com/blog/topics/threat-intelligence/tactics-techniques-procedures-associated-with-maze-ransomware-incidents |
+| 1 June 2023 | * | https://github.com/Casualtek/Ransomchats |
 
 > [!NOTE]
 > This list will also be used by others to contribute additional threat intelligence about tools used by ransomware gangs to the repo.

--- a/Tools/Exfiltration.md
+++ b/Tools/Exfiltration.md
@@ -17,7 +17,7 @@
 | FileZilla | Akira, Karakurt, AvosLocker, LockBit, Nokoyawa, Diavol, Scattered Spider* |
 | FreeFileSync | LockBit |
 | File[.]io | Mallox, Babuk, Lockbit |
-| Gofile[.io] | Avos |
+| Gofile[.io] | AvosLocker |
 | MEGA | Akira, Conti, mount-locker, Phobos, BlackCat, Karakurt, Scattered Spider*, LockBit, BianLian, Hive, Trigona, Quantum, INC Ransom, EvilCorp*, Avaddon, MONTI |
 | PrivatLab | Hive, REvil, BlackMatter, mount-locker, BlackMatter |
 | ProtonMail | Avaddon |
@@ -26,7 +26,7 @@
 | Restic | INC Ransom |
 | RClone | BlackSuit, Royal, Black Basta, Akira, Karakurt, AvosLocker, LockBit, BianLian, Hive, Daixin, Conti, Dagon Locker, Trigona, Quantum, REvil, 8BASE, INC Ransom, Cactus, EvilCorp*, Scattered Spider*, FiveHands |
 | Sendspace | Hive, LockBit, Avaddon, Conti, Darkside, Mallox, REvil |
-| share[.]riseup[.]net | Avos | 
+| share[.]riseup[.]net | AvosLocker | 
 | Temp[.]sh | Akira, LockBit |
 | Tempsend | LockBit |
 | Transfert-my-files | LockBit |

--- a/Tools/Exfiltration.md
+++ b/Tools/Exfiltration.md
@@ -8,6 +8,8 @@
 
 | Tool Name | Threat Group Usage |
 |---|---|
+| Anonfiles | Avaddon, LockBit |
+| Bashupload | DarkSide |
 | Cyberduck | Scattered Spider* |
 | Dropbox | BlackCat, Scattered Spider* |
 | FileZilla | Akira, Karakurt, AvosLocker, LockBit, Nokoyawa, Diavol, Scattered Spider* |
@@ -22,5 +24,8 @@
 | RClone | BlackSuit, Royal, Black Basta, Akira, Karakurt, AvosLocker, LockBit, BianLian, Hive, Daixin, Conti, Dagon Locker, Trigona, Quantum, REvil, 8BASE, INC Ransom, Cactus, EvilCorp*, Scattered Spider*, FiveHands |
 | Sendspace | Hive, LockBit, Avaddon, Conti, Darkside, Mallox, REvil |
 | Temp[.]sh | Akira, LockBit |
+| Tempsend | LockBit |
+| Transfert-my-files | LockBit |
+| Transfer[.]sh | LockBit |
 | UFile | Hive, Ranzy |
 | WinSCP | MAZE, Akira, Phobos, PLAY, LockBit, Conti, MONTI |

--- a/Tools/Exfiltration.md
+++ b/Tools/Exfiltration.md
@@ -12,6 +12,8 @@
 | Bashupload | DarkSide |
 | Cyberduck | Scattered Spider* |
 | Dropbox | BlackCat, Scattered Spider* |
+| Dropfiles | Conti |
+| Dropmefiles | Mallox |
 | FileZilla | Akira, Karakurt, AvosLocker, LockBit, Nokoyawa, Diavol, Scattered Spider* |
 | FreeFileSync | LockBit |
 | File[.]io | Mallox, Babuk, Lockbit |
@@ -19,10 +21,12 @@
 | MEGA | Akira, Conti, mount-locker, Phobos, BlackCat, Karakurt, Scattered Spider*, LockBit, BianLian, Hive, Trigona, Quantum, INC Ransom, EvilCorp*, Avaddon, MONTI |
 | PrivatLab | Hive, REvil, BlackMatter, mount-locker, BlackMatter |
 | ProtonMail | Avaddon |
-| PSCP | AvosLocker, MONTI | 
+| PSCP | AvosLocker, MONTI |
+[ Qaz[.]im | Conti, BlackBasta |
 | Restic | INC Ransom |
 | RClone | BlackSuit, Royal, Black Basta, Akira, Karakurt, AvosLocker, LockBit, BianLian, Hive, Daixin, Conti, Dagon Locker, Trigona, Quantum, REvil, 8BASE, INC Ransom, Cactus, EvilCorp*, Scattered Spider*, FiveHands |
 | Sendspace | Hive, LockBit, Avaddon, Conti, Darkside, Mallox, REvil |
+| share[.]riseup[.]net | Avos | 
 | Temp[.]sh | Akira, LockBit |
 | Tempsend | LockBit |
 | Transfert-my-files | LockBit |

--- a/Tools/Exfiltration.md
+++ b/Tools/Exfiltration.md
@@ -22,7 +22,7 @@
 | PrivatLab | Hive, REvil, BlackMatter, mount-locker, BlackMatter |
 | ProtonMail | Avaddon |
 | PSCP | AvosLocker, MONTI |
-[ Qaz[.]im | Conti, BlackBasta |
+| Qaz[.]im | Conti, BlackBasta |
 | Restic | INC Ransom |
 | RClone | BlackSuit, Royal, Black Basta, Akira, Karakurt, AvosLocker, LockBit, BianLian, Hive, Daixin, Conti, Dagon Locker, Trigona, Quantum, REvil, 8BASE, INC Ransom, Cactus, EvilCorp*, Scattered Spider*, FiveHands |
 | Sendspace | Hive, LockBit, Avaddon, Conti, Darkside, Mallox, REvil |

--- a/Tools/Exfiltration.md
+++ b/Tools/Exfiltration.md
@@ -12,12 +12,15 @@
 | Dropbox | BlackCat, Scattered Spider* |
 | FileZilla | Akira, Karakurt, AvosLocker, LockBit, Nokoyawa, Diavol, Scattered Spider* |
 | FreeFileSync | LockBit |
-| MEGA | Akira, Phobos, BlackCat, Karakurt, Scattered Spider*, LockBit, BianLian, Hive, Trigona, Quantum, INC Ransom, EvilCorp*, Avaddon, MONTI |
-| PrivatLab | Hive |
+| File[.]io | Mallox, Babuk, Lockbit |
+| Gofile[.io] | Avos |
+| MEGA | Akira, Conti, mount-locker, Phobos, BlackCat, Karakurt, Scattered Spider*, LockBit, BianLian, Hive, Trigona, Quantum, INC Ransom, EvilCorp*, Avaddon, MONTI |
+| PrivatLab | Hive, REvil, BlackMatter, mount-locker, BlackMatter |
 | ProtonMail | Avaddon |
 | PSCP | AvosLocker, MONTI | 
 | Restic | INC Ransom |
 | RClone | BlackSuit, Royal, Black Basta, Akira, Karakurt, AvosLocker, LockBit, BianLian, Hive, Daixin, Conti, Dagon Locker, Trigona, Quantum, REvil, 8BASE, INC Ransom, Cactus, EvilCorp*, Scattered Spider*, FiveHands |
-| Sendspace | Hive |
-| UFile | Hive |
+| Sendspace | Hive, LockBit, Avaddon, Conti, Darkside, Mallox, REvil |
+| Temp[.]sh | Akira, LockBit |
+| UFile | Hive, Ranzy |
 | WinSCP | MAZE, Akira, Phobos, PLAY, LockBit, Conti, MONTI |


### PR DESCRIPTION
Added Hosting Services Used by Ransomware Groups for Sharing Sensitive files with Victims
The hosting services listed were extracted from ransomware chat logs involving negotiations between ransomware groups and victims. Each service added can be found in the conversations with ransomware actors in the repo https://github.com/Casualtek/Ransomchats, example searches:

- Sendspace 
  - https://github.com/search?q=repo%3ACasualtek%2FRansomchats+Sendspace.com&type=code
- ufile
  - https://github.com/search?q=repo%3ACasualtek%2FRansomchats+UFile.io&type=code
- privatlab
  - https://github.com/search?q=repo%3ACasualtek%2FRansomchats+PrivatLab&type=code
- mega
  - https://github.com/search?q=repo%3ACasualtek%2FRansomchats+MEGA.nz&type=code
- temp.sh
  - https://github.com/search?q=repo%3ACasualtek%2FRansomchats+temp.sh&type=code
- file.io
  - https://github.com/search?q=repo%3ACasualtek%2FRansomchats+file.io&type=code
- sendspace.com
  - https://github.com/search?q=repo%3ACasualtek%2FRansomchats+sendspace.com&type=code
- anonfiles.com
  - https://github.com/search?q=repo%3ACasualtek%2FRansomchats+anonfiles&type=code 
  
...

