### PR TITLE
Update DefenseEvasion.md

### DIFF
--- a/ThreatIntel/ExtraThreatIntel.md
+++ b/ThreatIntel/ExtraThreatIntel.md
@@ -45,6 +45,7 @@
 | 25 April 2023 | Bassterlord* (REvil, RansomEXX, Avadon, LockBit) | https://analyst1.com/ransomware-diaries-volume-2/ |
 | 10 April 2023 | RagnarLocker | https://www.sygnia.co/blog/threat-actor-spotlight-ragnarlocker-ransomware/ |
 | 7 April 2023 | DarkBit+ | https://www.microsoft.com/en-us/security/blog/2023/04/07/mercury-and-dev-1084-destructive-attack-on-hybrid-environment |
+| 4 April 2023 | BabLock | https://www.group-ib.com/blog/bablock-ransomware/
 | 23 March 2023 | *Prophet Spider (MAZE, Egregor, MountLocker) | https://cloud.google.com/blog/topics/threat-intelligence/unc961-multiverse-financially-motivated/ |
 | 2 December 2022 | Scattered Spider* | https://www.crowdstrike.com/blog/analysis-of-intrusion-campaign-targeting-telecom-and-bpo-companies/ |
 | 17 November 2022 | Royal | https://www.microsoft.com/en-us/security/blog/2022/11/17/dev-0569-finds-new-ways-to-deliver-royal-ransomware-various-payloads/ |

--- a/Tools/AllTools.csv
+++ b/Tools/AllTools.csv
@@ -21,7 +21,7 @@ PingCastle,Parsec,Universal Virus Sniffer,NirSoft MailPassView,PowerShell Empire
 PowerView,PDQ Deploy,VirtualBox,NirSoft Netpass,PowerSploit,,,Sendspace
 PsInfo,Pulseway,YDArk,NirSoft OperaPassView,PwnTools,,,share[.]riseup[.]net
 PSNmap,Radmin,Zemana Anti-Rootkit driver,NirSoft RouterPassView,Responder,,,Temp[.]sh
-ReconFTW,Remote Manipulator System (RMS),,NirSoft RemoteDesktopPassView (rdpv),Rubeus,,,Tempsend
+ReconFTW,Remote Manipulator System (RMS),BEST_uninstallTool,NirSoft RemoteDesktopPassView (rdpv),Rubeus,,,Tempsend
 RustScan,RemotePC,,NirSoft SniffPass,SharpSploit,,,Transfert-my-files
 RVTools,RemoteUtilities,,NirSoft VNCPassView,Sliver,,,Transfer[.]sh
 S3 Browser,RPort,,NirSoft WebBrowserPassView,TinyMet,,,UFile

--- a/Tools/DefenseEvasion.md
+++ b/Tools/DefenseEvasion.md
@@ -11,6 +11,7 @@
 | Avast Anti-Rootkit driver | Cuba, AvosLocker, MONTI |
 | Backstab (Process Explorer driver) | Black Basta, LockBit | 
 | Bedevil | Scattered Spider* |
+| BEST_uninstallTool | BabLock |
 | Darkside (TrueSight driver) | CosmicBeetle* |
 | Defender Control | LockBit, Zola |
 | Dell Client driver | BlackByte |


### PR DESCRIPTION
* Added `BEST_uninstallTool.exe` tool used by BabLock [source](https://www.group-ib.com/blog/bablock-ransomware/)