### PR TITLE
Update Exfiltration.md

### DIFF
--- a/Tools/Exfiltration.md
+++ b/Tools/Exfiltration.md
@@ -17,6 +17,7 @@
 | Dropbox | BlackCat, Scattered Spider* |
 | Dropfiles | Conti |
 | Dropmefiles | Mallox |
+| EasyUpload.io | Qilin |
 | FileZilla | Akira, Karakurt, AvosLocker, LockBit, Nokoyawa, Diavol, Scattered Spider*, PYSA, BlackCat |
 | FreeFileSync | LockBit |
 | File[.]io | Mallox, Babuk, Lockbit |


### PR DESCRIPTION
Added EasyUpload.io, documented by Sophos: https://news.sophos.com/en-us/2025/04/01/sophos-mdr-tracks-ongoing-campaign-by-qilin-affiliates-targeting-screenconnect/